### PR TITLE
 Disk partition without LVM

### DIFF
--- a/dev/src/scripts/bootstrap.sh
+++ b/dev/src/scripts/bootstrap.sh
@@ -213,7 +213,7 @@ systemctl daemon-reload
 # Create directories for package managers to ensure they work as expected
 mkdir -p "${repository_disk_mount_path}/maven/repository"
 mkdir -p "${repository_disk_mount_path}/npm/npm-cache"
-mkdir -p "${repository_disk_mount_path}/go"
+mkdir -p "${repository_disk_mount_path}/go/bin"
 mkdir -p "${repository_disk_mount_path}/nuget/packages"
 # Fix permissions
 chown -R "${MY_USER}:${VAGRANT_BOX_ALL_USERS_GROUP}" "${repository_disk_mount_path}"

--- a/rocky-dev/rocky-dev.pkr.hcl
+++ b/rocky-dev/rocky-dev.pkr.hcl
@@ -19,7 +19,7 @@ variable "vm_name" {
 
 variable "vm_version" {
   type        = string
-  default     = "1.0.1"
+  default     = "1.0.2"
   description = "Version of Vagrant box"
 }
 
@@ -37,7 +37,7 @@ variable "base_ova_name" {
 
 variable "base_ova_version" {
   type        = string
-  default     = "1.0.2"
+  default     = "1.0.3"
   description = "Version of base OVA"
 }
 

--- a/rocky-dev/src/scripts/bootstrap.sh
+++ b/rocky-dev/src/scripts/bootstrap.sh
@@ -1070,7 +1070,7 @@ rm -rf /var/cache/dnf
 rm -rf "${repository_dir}"
 mkdir -p "${repository_dir}/maven/repository"
 mkdir -p "${repository_dir}/npm/npm-cache"
-mkdir -p "${repository_dir}/go"
+mkdir -p "${repository_dir}/go/bin"
 mkdir -p "${repository_dir}/nuget/packages"
 chown -R "${VM_USER}:${VM_USER_GROUP}" "${repository_dir}"
 chmod u=rwX,g=rX,o=rX -R "${repository_dir}"


### PR DESCRIPTION
* Migrated rocky-dev Vagrant box to the new base OVA with plain disk partitioning (no LVM).
* Minor enhancement for $GOPATH/bin being a part of PATH.