### PR TITLE
Double host-only network adapter fix

### DIFF
--- a/rocky-dev/rocky-dev.pkr.hcl
+++ b/rocky-dev/rocky-dev.pkr.hcl
@@ -19,7 +19,7 @@ variable "vm_name" {
 
 variable "vm_version" {
   type        = string
-  default     = "1.1.5"
+  default     = "1.1.6"
   description = "Version of Vagrant box"
 }
 

--- a/rocky-dev/src/vagrantfile.template
+++ b/rocky-dev/src/vagrantfile.template
@@ -1,6 +1,5 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "rocky-dev"
-  config.vm.network "private_network", ip: "192.168.56.64"
   config.vm.provider "virtualbox" do |vb|
     vb.gui = true
     vb.name = "rocky-dev"


### PR DESCRIPTION
Removed configuration of private (VirtualBox host-only) network adapter from rocky-dev Vagrant box keeping it in Vagrantfile for dev VM only to avoid 2 private network adapters being configured for dev VM.